### PR TITLE
Implement API endpoint for ENEM results

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,20 @@ scrapy crawl enem
 
 The spider will authenticate using the variables above and will download the most recent result file, saving it as `resultado_registry_<number>_<year>.txt` (or `.csv`, depending on the portal).
 
+## API
+
+This project also exposes a small FastAPI application that runs the spider and
+returns the retrieved file content. Install the additional dependency
+`fastapi` (and an ASGI server such as `uvicorn`) and run:
+
+```bash
+uvicorn api:app
+```
+
+Once running you can request the result with:
+
+```bash
+curl "http://localhost:8000/consulta?registry=151000163729&year=2015"
+```
+
 

--- a/api.py
+++ b/api.py
@@ -1,0 +1,27 @@
+from fastapi import FastAPI, HTTPException, Response
+from scrapy.crawler import CrawlerProcess
+from scrapy.utils.project import get_project_settings
+from enem_solicitacao_py.spiders.enem_spider import EnemSpider
+from dotenv import load_dotenv
+
+load_dotenv()
+
+app = FastAPI()
+
+@app.get('/consulta')
+def consulta(registry: str, year: str):
+    settings = get_project_settings()
+    process = CrawlerProcess(settings)
+    spider = EnemSpider(registry=registry, year=year)
+    process.crawl(spider)
+    process.start()
+
+    content = getattr(spider, 'result_content', None)
+    if content is None:
+        raise HTTPException(status_code=404, detail='Nenhum conteudo gerado')
+
+    media_type = 'text/plain'
+    ext = getattr(spider, 'result_extension', '')
+    if ext and ext.lower() == '.csv':
+        media_type = 'text/csv'
+    return Response(content=content, media_type=media_type)


### PR DESCRIPTION
## Summary
- enable `EnemSpider` to accept registry and year parameters
- expose result content in the spider
- create `api.py` with a FastAPI endpoint `/consulta`
- document API usage in README

## Testing
- `python -m py_compile api.py enem_solicitacao_py/spiders/enem_spider.py`
- `pip install fastapi uvicorn -q` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_684b3362866483319411f21ccb3f1bfb